### PR TITLE
feat: Add Compose Multiplatform

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.compose.multiplatform) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.secrets) apply false
     alias(libs.plugins.gms.googleServices) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ androidxWork = "2.9.0"
 arrow = "1.2.4"
 bio = "1.1.0"
 coil = "2.6.0"
+compose-multiplatform = "1.6.11"
 deeplinkdispatch = "6.2.2"
 dependencyGuard = "0.5.0"
 emoji2-emojipicker = "1.4.0"
@@ -347,6 +348,7 @@ android-library = { id = "com.android.library", version.ref = "androidGradlePlug
 android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidxMacroBenchmark"}
 cacheFixPlugin = { id = "org.gradle.android.cache-fix", version = "3.0.1" }
+compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 dependencyGuard = { id = "com.dropbox.dependency-guard", version.ref = "dependencyGuard" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.sqldelight)
     kotlin("plugin.serialization")
@@ -19,8 +20,8 @@ kotlin {
         }
     }
 
-    // apple
-    iosX64()
+    // apple do not need x64
+    // iosX64()
     iosArm64()
     iosSimulatorArm64()
 


### PR DESCRIPTION
This commit adds Compose Multiplatform to the project.

- Adds the Compose Multiplatform plugin to the shared module. -
 Removes the iosX64 target as it is not needed for Compose Multiplatform.
- Applies the Compose Multiplatform plugin to the root project.