### PR TITLE
compile sdk 35 -> 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # project
-compileSdk = "35"
+compileSdk = "36"
 minSdk = "26"
 targetSdk = "34"
 versionCode = "20250128"


### PR DESCRIPTION
Updates the `compileSdk` version from 35 to 36 in `libs.versions.toml`. This change aligns the project with the latest Android API level and the associated Android Gradle Plugin.