### PR TITLE
feat: setup gradle cache encryption key

### DIFF
--- a/.github/workflows/app_arducon.yml
+++ b/.github/workflows/app_arducon.yml
@@ -9,25 +9,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: cache gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: set up JDK 17
         uses: actions/setup-java@v4.7.1
         with:
           distribution: "zulu" # See 'Supported distributions' for available options
           java-version: "17"
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/app_cnubus.yml
+++ b/.github/workflows/app_cnubus.yml
@@ -9,25 +9,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: cache gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: set up JDK 17
         uses: actions/setup-java@v4.7.1
         with:
           distribution: "zulu" # See 'Supported distributions' for available options
           java-version: "17"
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/app_comssa.yml
+++ b/.github/workflows/app_comssa.yml
@@ -9,26 +9,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-
-      - name: cache gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: set up JDK 17
         uses: actions/setup-java@v4.7.1
         with:
           distribution: "zulu" # See 'Supported distributions' for available options
           java-version: "17"
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/app_deploy.yml
+++ b/.github/workflows/app_deploy.yml
@@ -11,25 +11,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: cache gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: set up JDK 17
         uses: actions/setup-java@v4.7.1
         with:
           distribution: "zulu"
           java-version: "17"
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/app_my_grade.yml
+++ b/.github/workflows/app_my_grade.yml
@@ -9,25 +9,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: cache gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
 
       - name: set up JDK 17
         uses: actions/setup-java@v4.7.1
         with:
           distribution: "zulu" # See 'Supported distributions' for available options
           java-version: "17"
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/app_nanda.yml
+++ b/.github/workflows/app_nanda.yml
@@ -9,25 +9,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: cache gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: set up JDK 17
         uses: actions/setup-java@v4.7.1
         with:
           distribution: "zulu" # See 'Supported distributions' for available options
           java-version: "17"
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,11 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
This commit introduces the setup of a Gradle cache encryption key across multiple workflow files (`ci.yml`, `app_my_grade.yml`, `app_nanda.yml`, `app_cnubus.yml`, `app_comssa.yml`, `app_arducon.yml`, `app_deploy.yml`). It removes redundant gradle setup steps and configures the `gradle/actions/setup-gradle@v4` action to use the `cache-encryption-key` input with the value from the `GRADLE_ENCRYPTION_KEY` secret. Also, removes the previously added gradle cache.