### PR TITLE
Enable coreLibraryDesugaring dependency

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/keelim/builds/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/keelim/builds/KotlinAndroid.kt
@@ -54,7 +54,7 @@ fun Project.configureKotlinAndroid(
     configureKotlin()
 
     dependencies {
-        // add("coreLibraryDesugaring", libs.findLibrary("android.desugarJdkLibs").get())
+        add("coreLibraryDesugaring", libs.findLibrary("android.desugarJdkLibs").get())
         add("implementation", libs.findLibrary("kotlinx-collections-immutable").get())
     }
 }


### PR DESCRIPTION
Uncommented the addition of the 'coreLibraryDesugaring' dependency using 'android.desugarJdkLibs' to ensure desugaring support is included in Kotlin Android projects.