### PR TITLE
Add composeApp module with Compose Hot Reload support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     alias(libs.plugins.cacheFixPlugin) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.compose.multiplatform) apply false
+    alias(libs.plugins.compose.hot.reload) apply false
     alias(libs.plugins.dependency.analysis) apply false
     alias(libs.plugins.dependencyGuard) apply false
     alias(libs.plugins.firebase.crashlytics) apply false

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.compose.hot.reload)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.compose.compiler)
+}
+
+kotlin {
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ bio = "1.1.0"
 circuit = "0.29.1"
 coil = "2.7.0"
 compose-multiplatform = "1.8.2"
+composeHotReload = "1.0.0-beta03"
 deeplinkdispatch = "6.2.2"
 dependency-analysis = "2.19.0"
 dependencyGuard = "0.5.0"
@@ -379,6 +380,7 @@ baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidxMacr
 cacheFixPlugin = { id = "org.gradle.android.cache-fix", version = "3.0.1" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+compose-hot-reload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 dependencyGuard = { id = "com.dropbox.dependency-guard", version.ref = "dependencyGuard" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,7 @@ include(
     ":app-comssa",
     ":benchmarks",
     // ":catalog",
+    ":composeApp",
     ":core:common",
     ":core:common-android",
     ":core:compose-core",


### PR DESCRIPTION
Introduces a new composeApp module configured for Kotlin Multiplatform and Compose Hot Reload. Updates build scripts and dependency versions to include Compose Hot Reload plugin, and registers the new module in settings.gradle.kts.