### PR TITLE
build(proguard): apply -repackageclasses to app modules

### DIFF
--- a/app-arducon/proguard-rules.pro
+++ b/app-arducon/proguard-rules.pro
@@ -17,3 +17,4 @@
 -keep @kotlinx.serialization.Serializable class * {*;}
 -dontwarn kotlin.native.ObjCName
 -dontwarn okhttp3.internal.Util
+-repackageclasses

--- a/app-cnubus/proguard-rules.pro
+++ b/app-cnubus/proguard-rules.pro
@@ -17,3 +17,4 @@
 -keep @kotlinx.serialization.Serializable class * {*;}
 -dontwarn kotlin.native.ObjCName
 -dontwarn okhttp3.internal.Util
+-repackageclasses

--- a/app-comssa/proguard-rules.pro
+++ b/app-comssa/proguard-rules.pro
@@ -17,3 +17,4 @@
 -keep @kotlinx.serialization.Serializable class * {*;}
 -dontwarn kotlin.native.ObjCName
 -dontwarn okhttp3.internal.Util
+-repackageclasses

--- a/app-my-grade/proguard-rules.pro
+++ b/app-my-grade/proguard-rules.pro
@@ -17,3 +17,4 @@
 -keep @kotlinx.serialization.Serializable class * {*;}
 -dontwarn kotlin.native.ObjCName
 -dontwarn okhttp3.internal.Util
+-repackageclasses

--- a/app-mysenior/proguard-rules.pro
+++ b/app-mysenior/proguard-rules.pro
@@ -15,3 +15,4 @@
 -dontwarn io.ktor.client.plugins.contentnegotiation.ContentNegotiation$Plugin
 -dontwarn io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 -keep @kotlinx.serialization.Serializable class * {*;}
+-repackageclasses

--- a/app-nanda/proguard-rules.pro
+++ b/app-nanda/proguard-rules.pro
@@ -17,3 +17,4 @@
 -keep @kotlinx.serialization.Serializable class * {*;}
 -dontwarn kotlin.native.ObjCName
 -dontwarn okhttp3.internal.Util
+-repackageclasses


### PR DESCRIPTION
## Purpose
Introduce `-repackageclasses` to ProGuard/R8 to repackage classes for stronger obfuscation and potential size optimizations.

## Changes
Added a single line `-repackageclasses` to the following files:
- app-arducon/proguard-rules.pro
- app-cnubus/proguard-rules.pro
- app-comssa/proguard-rules.pro
- app-my-grade/proguard-rules.pro
- app-mysenior/proguard-rules.pro
- app-nanda/proguard-rules.pro

## Expected impact
- Smaller binary size in some cases; stronger obfuscation.
- FQCNs may change due to repackaging.

## Risks/notes
- Reflection (including JNI) or hard-coded FQCNs can break when class/package names change.
- Existing keep rules (e.g., `@kotlinx.serialization.Serializable`) remain, so common serialization/network usages are likely unaffected.

## Validation
- Build release for each affected app (assembleRelease/bundleRelease) and verify success.
- Smoke-test app launch and key flows; watch for reflection-related issues.

## Rollback
- Remove the `-repackageclasses` line from the affected `proguard-rules.pro` files.

## Misc
- Base: `develop` (can switch if you prefer another base).