### PR TITLE
Introduce 'android.r8.optimizedResourceShrinking'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
       - name: Set environment
         run: |
           echo '${{ secrets.GOOGLE_SERVICE_JSON }}' | base64 -d > ./app-cnubus/google-services.json

--- a/build-logic/convention/src/main/kotlin/KeelimAndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KeelimAndroidApplicationPlugin.kt
@@ -40,7 +40,6 @@ class KeelimAndroidApplicationPlugin : Plugin<Project> {
                 buildTypes.getByName("release").apply {
                     isMinifyEnabled = true
                     isShrinkResources = true
-                    vcsInfo.include = true
                     proguardFiles(
                         getDefaultProguardFile("proguard-android-optimize.txt"),
                         "proguard-rules.pro"

--- a/build-logic/convention/src/main/kotlin/KeelimAndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KeelimAndroidApplicationPlugin.kt
@@ -38,6 +38,11 @@ class KeelimAndroidApplicationPlugin : Plugin<Project> {
                     buildConfig = true
                 }
                 buildTypes {
+                    getByName("debug") {
+                        isMinifyEnabled = false
+                        isShrinkResources = false
+                        isCrunchPngs = false
+                    }
                     getByName("release") {
                         isMinifyEnabled = true
                         isShrinkResources = true

--- a/build-logic/convention/src/main/kotlin/KeelimAndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KeelimAndroidApplicationPlugin.kt
@@ -37,13 +37,15 @@ class KeelimAndroidApplicationPlugin : Plugin<Project> {
                 with(buildFeatures) {
                     buildConfig = true
                 }
-                buildTypes.getByName("release").apply {
-                    isMinifyEnabled = true
-                    isShrinkResources = true
-                    proguardFiles(
-                        getDefaultProguardFile("proguard-android-optimize.txt"),
-                        "proguard-rules.pro"
-                    )
+                buildTypes {
+                    getByName("release") {
+                        isMinifyEnabled = true
+                        isShrinkResources = true
+                        proguardFiles(
+                            getDefaultProguardFile("proguard-android-optimize.txt"),
+                            "proguard-rules.pro"
+                        )
+                    }
                 }
                 lint {
                     abortOnError = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,3 +44,4 @@ org.jetbrains.compose.experimental.uikit.enabled=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.configuration-cache.problems=warn
+android.r8.optimizedResourceShrinking=true


### PR DESCRIPTION
This pull request introduces improvements to the Android build configuration and resource shrinking, as well as a minor cleanup in the CI workflow. The main changes focus on refining build type settings, enabling optimized resource shrinking, and removing redundant commands.

**Android build configuration updates:**
* Added explicit configuration for the `debug` build type to disable minification, resource shrinking, and PNG crunching in `KeelimAndroidApplicationPlugin.kt`. This helps speed up debug builds and avoids unnecessary processing.
* Refined the `release` build type settings to ensure minification and resource shrinking are enabled, and clarified the proguard configuration.

**Resource shrinking optimization:**
* Enabled optimized resource shrinking by adding `android.r8.optimizedResourceShrinking=true` to `gradle.properties`, which can help reduce APK size.

**CI workflow cleanup:**
* Removed a redundant step that granted execute permission to `gradlew` twice in `.github/workflows/ci.yml`, streamlining the workflow.