### PR TITLE
Migrate to new hiltViewModel import in Compose screens

### DIFF
--- a/app-arducon/src/main/java/com/keelim/arducon/ui/ArduconHost.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/ArduconHost.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
-import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay

--- a/app-arducon/src/main/java/com/keelim/arducon/ui/ArduconHost.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/ArduconHost.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider

--- a/app-arducon/src/main/java/com/keelim/arducon/ui/screen/deeplink/CreateDeepLinkScreen.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/screen/deeplink/CreateDeepLinkScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.resource.space12
 import com.keelim.composeutil.resource.space16

--- a/app-arducon/src/main/java/com/keelim/arducon/ui/screen/main/MainScreen.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/screen/main/MainScreen.kt
@@ -73,7 +73,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.keelim.arducon.ui.screen.main.MainViewModel.QrDialogState

--- a/app-arducon/src/main/java/com/keelim/arducon/ui/screen/ogtag/OgTagPreviewScreen.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/screen/ogtag/OgTagPreviewScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.keelim.composeutil.resource.space8
 

--- a/app-arducon/src/main/java/com/keelim/arducon/ui/screen/playground/PlaygroundScreen.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/screen/playground/PlaygroundScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.arducon.R
 import com.keelim.common.extensions.saveQrBitmapToGallery

--- a/app-arducon/src/main/java/com/keelim/arducon/ui/screen/saastatus/main/SaastatusScreen.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/screen/saastatus/main/SaastatusScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.arducon.ui.screen.saastatus.SaastatusColumn
 import com.keelim.composeutil.component.layout.Loading

--- a/app-arducon/src/main/java/com/keelim/arducon/ui/screen/saastatus/search/SaastatusSearchScreen.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/screen/saastatus/search/SaastatusSearchScreen.kt
@@ -2,7 +2,7 @@ package com.keelim.arducon.ui.screen.saastatus.search
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.arducon.ui.screen.saastatus.SaastatusColumn
 
 @Composable

--- a/app-arducon/src/main/java/com/keelim/arducon/ui/screen/search/SearchScreen.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/screen/search/SearchScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.resource.space16
 

--- a/app-arducon/src/main/java/com/keelim/arducon/ui/screen/stats/StatsScreen.kt
+++ b/app-arducon/src/main/java/com/keelim/arducon/ui/screen/stats/StatsScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.github.tehras.charts.bar.BarChart
 import com.github.tehras.charts.bar.BarChartData
 import com.github.tehras.charts.bar.renderer.label.SimpleValueDrawer

--- a/app-cnubus/src/main/java/com/keelim/cnubus/ui/CnubusHost.kt
+++ b/app-cnubus/src/main/java/com/keelim/cnubus/ui/CnubusHost.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.EntryProviderBuilder
-import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay

--- a/app-cnubus/src/main/java/com/keelim/cnubus/ui/screen/main/MainScreen.kt
+++ b/app-cnubus/src/main/java/com/keelim/cnubus/ui/screen/main/MainScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.util.trace
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.cnubus.ui.screen.root.RootRoute
 import com.keelim.cnubus.ui.screen.root.RootViewModel
 import com.keelim.cnubus.ui.screen.setting.ScreenAction

--- a/app-cnubus/src/main/java/com/keelim/cnubus/ui/screen/map/screen/map/MapScreen.kt
+++ b/app-cnubus/src/main/java/com/keelim/cnubus/ui/screen/map/screen/map/MapScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.google.android.gms.maps.model.CameraPosition

--- a/app-cnubus/src/main/java/com/keelim/cnubus/ui/screen/root/RootScreen.kt
+++ b/app-cnubus/src/main/java/com/keelim/cnubus/ui/screen/root/RootScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.component.layout.EmptyView
 import com.keelim.composeutil.component.layout.Loading

--- a/app-comssa/src/main/java/com/keelim/comssa/ui/screen/ComssaHost.kt
+++ b/app-comssa/src/main/java/com/keelim/comssa/ui/screen/ComssaHost.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.SheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
-import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay

--- a/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/calendar/CalendarScreen.kt
+++ b/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/calendar/CalendarScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 @Composable
 fun CalendarRoute(

--- a/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/ecocal/EcocalScreen.kt
+++ b/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/ecocal/EcocalScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.commonAndroid.model.SealedUiState
 import com.keelim.composeutil.component.fab.FabButtonItem

--- a/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/finance/FinanceScreen.kt
+++ b/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/finance/FinanceScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.commonAndroid.model.SealedUiState
 import com.keelim.composeutil.component.fab.FabButtonItem

--- a/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/finance/FinanceSection.kt
+++ b/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/finance/FinanceSection.kt
@@ -54,7 +54,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.composeutil.component.fab.FabButtonItem
 import com.keelim.composeutil.resource.space12
 import com.keelim.composeutil.resource.space16

--- a/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/flash/FlashCardScreen.kt
+++ b/app-comssa/src/main/java/com/keelim/comssa/ui/screen/main/flash/FlashCardScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.resource.space12
 

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/MyGradeHost.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/MyGradeHost.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.EntryProviderBuilder
-import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/grade/GradeScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/grade/GradeScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.component.appbar.NavigationBackArrowBar
 import com.keelim.composeutil.resource.space12

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/grade/edit/EditRoute.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/grade/edit/EditRoute.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.commonAndroid.model.SealedUiState
 import com.keelim.composeutil.component.layout.EmptyView

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/grade/notes/NotesRoute.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/grade/notes/NotesRoute.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.commonAndroid.model.SealedUiState
 import com.keelim.composeutil.component.layout.EmptyView

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/history/HistoryScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/history/HistoryScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.component.appbar.NavigationBackArrowBar
 import com.keelim.composeutil.component.layout.EmptyView

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/main/MainScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/main/MainScreen.kt
@@ -48,7 +48,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.component.fab.FabButtonItem
 import com.keelim.composeutil.component.fab.FabButtonMain

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/task/TaskScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/task/TaskScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.commonAndroid.model.SealedUiState
 import com.keelim.composeutil.component.layout.EmptyView

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/task/chart/TaskChartScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/task/chart/TaskChartScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.commonAndroid.model.SealedUiState
 import com.keelim.composeutil.component.canvas.chart.PieChartEntry

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/timer/TimerScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/timer/TimerScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.component.custom.NumberPickerList
 import com.keelim.composeutil.resource.space16

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/timer/history/TimerHistoryScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/timer/history/TimerHistoryScreen.kt
@@ -3,7 +3,7 @@ package com.keelim.mygrade.ui.screen.timer.history
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.composeutil.component.box.ReadyServiceBox
 
 @Composable

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/water/WaterScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/water/WaterScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.composeutil.component.appbar.NavigationBackArrowBar
 
 @Composable

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/word/show/WordShowScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/word/show/WordShowScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.composeutil.component.box.ReadyServiceBox
 
 @Composable

--- a/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/word/write/WordWriteScreen.kt
+++ b/app-my-grade/src/main/java/com/keelim/mygrade/ui/screen/word/write/WordWriteScreen.kt
@@ -3,7 +3,7 @@ package com.keelim.mygrade.ui.screen.word.write
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.composeutil.component.box.ReadyServiceBox
 
 @Composable

--- a/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/NandaHost.kt
+++ b/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/NandaHost.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.EntryProviderBuilder
-import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay

--- a/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/category/CategoryScreen.kt
+++ b/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/category/CategoryScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.util.permission.SimpleAcquirePermissions
 import kotlinx.collections.immutable.persistentListOf

--- a/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/diagnosis/DiagnosisScreen.kt
+++ b/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/diagnosis/DiagnosisScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.component.layout.EmptyView
 import com.keelim.composeutil.component.layout.Loading

--- a/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/exercise/ExerciseScreen.kt
+++ b/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/exercise/ExerciseScreen.kt
@@ -2,7 +2,7 @@ package com.keelim.nandadiagnosis.ui.screen.exercise
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 @Composable
 fun ExerciseRoute(

--- a/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/food/edit/FoodEditScreen.kt
+++ b/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/food/edit/FoodEditScreen.kt
@@ -2,7 +2,7 @@ package com.keelim.nandadiagnosis.ui.screen.food.edit
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 @Composable
 fun FoodEditRoute(

--- a/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/food/overview/FoodScreen.kt
+++ b/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/food/overview/FoodScreen.kt
@@ -2,7 +2,7 @@ package com.keelim.nandadiagnosis.ui.screen.food.overview
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 @Composable
 fun FoodRoute(

--- a/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/length/LengthScreen.kt
+++ b/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/length/LengthScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.composeutil.component.chart.LengthChartPoint
 import com.keelim.composeutil.component.chart.LengthLineChart
 import com.keelim.model.LengthRecord

--- a/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/nutrient/NutrientScreen.kt
+++ b/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/nutrient/NutrientScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.keelim.composeutil.component.appbar.NavigationBackArrowBar

--- a/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/nutrient/timer/NutrientTimerScreen.kt
+++ b/app-nanda/src/main/java/com/keelim/nandadiagnosis/ui/screen/nutrient/timer/NutrientTimerScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.composeutil.component.custom.NumberPickerList
 import com.keelim.composeutil.resource.space16
 import com.keelim.composeutil.resource.space24

--- a/core/common-android/src/main/java/com/keelim/commonAndroid/ui/crash/CrashRoute.kt
+++ b/core/common-android/src/main/java/com/keelim/commonAndroid/ui/crash/CrashRoute.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.composeutil.component.appbar.NavigationBackArrowBar
 import com.keelim.composeutil.resource.space8
 

--- a/feature/ui-setting/src/main/java/com/keelim/setting/screen/admin/AdminScreen.kt
+++ b/feature/ui-setting/src/main/java/com/keelim/setting/screen/admin/AdminScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.keelim.composeutil.component.appbar.NavigationBackArrowBar
 import com.keelim.composeutil.resource.space8
 

--- a/feature/ui-setting/src/main/java/com/keelim/setting/screen/alarm/AlarmScreen.kt
+++ b/feature/ui-setting/src/main/java/com/keelim/setting/screen/alarm/AlarmScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.commonAndroid.model.SealedUiState
 import com.keelim.composeutil.component.layout.Loading

--- a/feature/ui-setting/src/main/java/com/keelim/setting/screen/event/EventScreen.kt
+++ b/feature/ui-setting/src/main/java/com/keelim/setting/screen/event/EventScreen.kt
@@ -2,7 +2,7 @@ package com.keelim.setting.screen.event
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 @Composable
 fun EventRoute() {

--- a/feature/ui-setting/src/main/java/com/keelim/setting/screen/faq/FaqScreen.kt
+++ b/feature/ui-setting/src/main/java/com/keelim/setting/screen/faq/FaqScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.component.layout.EmptyView
 import com.keelim.composeutil.component.layout.Loading

--- a/feature/ui-setting/src/main/java/com/keelim/setting/screen/lab/LabRoute.kt
+++ b/feature/ui-setting/src/main/java/com/keelim/setting/screen/lab/LabRoute.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.resource.space4
 import com.keelim.composeutil.resource.space8

--- a/feature/ui-setting/src/main/java/com/keelim/setting/screen/maintenance/MaintenanceScreen.kt
+++ b/feature/ui-setting/src/main/java/com/keelim/setting/screen/maintenance/MaintenanceScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable

--- a/feature/ui-setting/src/main/java/com/keelim/setting/screen/notification/NotificationScreen.kt
+++ b/feature/ui-setting/src/main/java/com/keelim/setting/screen/notification/NotificationScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.component.layout.EmptyView
 import com.keelim.composeutil.resource.space12

--- a/feature/ui-setting/src/main/java/com/keelim/setting/screen/settings/SettingsScreen.kt
+++ b/feature/ui-setting/src/main/java/com/keelim/setting/screen/settings/SettingsScreen.kt
@@ -60,7 +60,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.component.layout.EmptyView
 import com.keelim.composeutil.resource.space12

--- a/feature/ui-setting/src/main/java/com/keelim/setting/screen/theme/ThemeScreen.kt
+++ b/feature/ui-setting/src/main/java/com/keelim/setting/screen/theme/ThemeScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.util.fastForEach
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.keelim.composeutil.resource.space8
 import com.keelim.shared.data.model.ThemeType


### PR DESCRIPTION
Replaces all usages of androidx.hilt.navigation.compose.hiltViewModel with androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel across multiple modules and screens. This update aligns with the latest Hilt and Jetpack Compose integration recommendations.