### PR TITLE
Delete Work object and use compose.resource 

### DIFF
--- a/build-logic/convention/src/main/kotlin/KeelimAndroidLibraryComposePlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KeelimAndroidLibraryComposePlugin.kt
@@ -14,7 +14,6 @@ class KeelimAndroidLibraryComposePlugin : Plugin<Project> {
 
             apply(plugin = "com.android.library")
             apply(plugin = "org.jetbrains.kotlin.plugin.compose")
-            apply(plugin = "org.jetbrains.kotlin.plugin.compose")
 
             configureAndroidCompose(
                 commonExtension = extensions.getByType<LibraryExtension>(),

--- a/build-logic/convention/src/main/kotlin/KeelimMultiPlatformConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KeelimMultiPlatformConventionPlugin.kt
@@ -4,7 +4,6 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
@@ -13,6 +12,8 @@ class KeelimMultiPlatformConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply(plugin = libs.findPlugin("kotlinMultiplatform").get().get().pluginId)
+            apply(plugin = libs.findPlugin("compose-multiplatform").get().get().pluginId)
+            apply(plugin = libs.findPlugin("compose-compiler").get().get().pluginId)
             extensions.configure<KotlinMultiplatformExtension> {
                 jvm("desktop")
                 if (project.name.contains("shared").not()) {
@@ -37,12 +38,7 @@ class KeelimMultiPlatformConventionPlugin : Plugin<Project> {
                         binaries.executable()
                     }
                 }
-
-                androidTarget {
-                    compilerOptions {
-                        jvmTarget.set(JvmTarget.JVM_17)
-                    }
-                }
+                androidTarget()
             }
         }
     }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -2,12 +2,8 @@
 
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.compose.hot.reload)
-    alias(libs.plugins.compose.multiplatform)
-    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.android.application)
     alias(libs.plugins.keelim.multiplatform)
 }

--- a/core/component/build.gradle.kts
+++ b/core/component/build.gradle.kts
@@ -3,15 +3,11 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.compose.multiplatform)
-    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.android.library)
     alias(libs.plugins.keelim.multiplatform)
 }
 
 kotlin {
-    androidTarget()
     sourceSets {
         androidMain.dependencies {
             implementation(libs.accompanist.permissions)

--- a/core/resource/build.gradle.kts
+++ b/core/resource/build.gradle.kts
@@ -21,6 +21,11 @@ kotlin {
     }
 }
 
+compose.resources {
+    publicResClass = true
+    packageOfResClass = "com.keelim.core.resource"
+}
+
 android {
     namespace = "com.keelim.core.resource"
     compileSdk = libs.versions.compileSdk.get().toInt()

--- a/core/resource/build.gradle.kts
+++ b/core/resource/build.gradle.kts
@@ -1,19 +1,9 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.android.library)
+    alias(libs.plugins.keelim.multiplatform)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_1_8
-        }
-    }
-
-    jvm("desktop")
-
     listOf(
         iosX64(),
         iosArm64(),
@@ -22,6 +12,11 @@ kotlin {
         iosTarget.binaries.framework {
             baseName = "ALL"
             isStatic = true
+        }
+    }
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.components.resources)
         }
     }
 }

--- a/core/resource/src/commonMain/kotlin/com/keelim/core/string/Word.kt
+++ b/core/resource/src/commonMain/kotlin/com/keelim/core/string/Word.kt
@@ -1,5 +1,0 @@
-package com.keelim.core.string
-
-object Word {
-    const val project = "All"
-}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.keelim.android.application.room)
     kotlin("plugin.serialization")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.okio)
             implementation(libs.circuit.foundation)
+            implementation(compose.components.resources)
 
             api(projects.core.resource)
             api(libs.androidx.dataStore.preferences)

--- a/shared/src/commonMain/kotlin/com/keelim/shared/ui/DesktopWindow.kt
+++ b/shared/src/commonMain/kotlin/com/keelim/shared/ui/DesktopWindow.kt
@@ -1,0 +1,20 @@
+package com.keelim.shared.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.Window
+import com.keelim.core.resource.Res
+import com.keelim.core.resource.project
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun DesktopWindow(
+    onCloseRequest: () -> Unit,
+    content: @Composable FrameWindowScope.() -> Unit
+) {
+    Window(
+        onCloseRequest = onCloseRequest,
+        title = stringResource(Res.string.project),
+        content = content
+    )
+}

--- a/shared/src/desktopMain/kotlin/com/keelim/shared/Main.kt
+++ b/shared/src/desktopMain/kotlin/com/keelim/shared/Main.kt
@@ -1,15 +1,14 @@
 package com.keelim.shared
 
-import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import com.keelim.core.string.Word
+import com.keelim.shared.ui.DesktopWindow
 
 fun main() {
     application {
-        Window(
-            onCloseRequest = ::exitApplication,
-            title = Word.project,
+        DesktopWindow(
+            onCloseRequest = ::exitApplication
         ) {
+            
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the project’s plugin and build configuration to streamline multiplatform and Compose setup, while also cleaning up resource management and improving desktop window handling. The main changes consolidate plugin application, remove redundant configuration, and introduce a more maintainable approach to resource usage and UI composition.

**Plugin and Build Configuration Simplification:**

* The multiplatform and Compose plugins are now applied centrally via the custom `KeelimMultiPlatformConventionPlugin`, removing the need to declare them in individual module build files such as `composeApp/build.gradle.kts`, `core/component/build.gradle.kts`, `core/resource/build.gradle.kts`, and `shared/build.gradle.kts`. This reduces duplication and centralizes configuration. [[1]](diffhunk://#diff-3261c681a5d672208c62b037e1c257dbf17c23faf6496bcea1ca74fb5f1b213bR15-R16) [[2]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aL5-L10) [[3]](diffhunk://#diff-98f9d0f4387222373357a1797238f12fe200ba94fd8b1d06f10d0cba9a7a7ae8L6-L14) [[4]](diffhunk://#diff-95fdbc2f3bee457069f41664dc24108de81d4ac3941fb6804bc7e5c37a286e98L1-L16) [[5]](diffhunk://#diff-cf9ae3b1eb7273a914f22b1e6d22d8447f88df0e7245a5b856fb751e507b979bL4)
* The redundant repeated application of the `org.jetbrains.kotlin.plugin.compose` plugin in `KeelimAndroidLibraryComposePlugin.kt` has been removed.

**Resource Management Improvements:**

* Resource configuration for Compose has been added to `core/resource/build.gradle.kts`, enabling `publicResClass` and specifying the package for generated resource classes. This makes resources accessible across modules and improves code organization.
* The obsolete `Word.kt` object has been deleted, and resource strings are now accessed via Compose’s resource system, improving localization and maintainability. [[1]](diffhunk://#diff-4677f9e62276bc231f06779d60fb19fe1bc6c78c8b097b10d26074aa7705b0d9L1-L5) [[2]](diffhunk://#diff-4cbb12331dba0401014b60575826836a01ef5f09d36d7ee1803f488911e024bfR1-R20) [[3]](diffhunk://#diff-136019b00791f6c8a68033f9a6fb90dec8a9c5ae6fb0ad015387fc5e031737dcL3-R11)

**Desktop UI Refactor:**

* The desktop window setup has been refactored to use a new `DesktopWindow` composable, which retrieves its title from the resource system instead of a hardcoded string. This change improves consistency and leverages Compose’s resource management. [[1]](diffhunk://#diff-4cbb12331dba0401014b60575826836a01ef5f09d36d7ee1803f488911e024bfR1-R20) [[2]](diffhunk://#diff-136019b00791f6c8a68033f9a6fb90dec8a9c5ae6fb0ad015387fc5e031737dcL3-R11)

**Configuration Cleanup:**

* Unused imports and explicit JVM target configuration have been removed from build scripts, relying instead on convention plugin defaults for cleaner and more maintainable build files. [[1]](diffhunk://#diff-3261c681a5d672208c62b037e1c257dbf17c23faf6496bcea1ca74fb5f1b213bL7) [[2]](diffhunk://#diff-3261c681a5d672208c62b037e1c257dbf17c23faf6496bcea1ca74fb5f1b213bL40-R41) [[3]](diffhunk://#diff-95fdbc2f3bee457069f41664dc24108de81d4ac3941fb6804bc7e5c37a286e98L1-L16)

**Dependency Management:**

* Modules now consistently declare dependencies on shared resources using `compose.components.resources`, ensuring resource access and reducing duplication. [[1]](diffhunk://#diff-95fdbc2f3bee457069f41664dc24108de81d4ac3941fb6804bc7e5c37a286e98R17-R26) [[2]](diffhunk://#diff-cf9ae3b1eb7273a914f22b1e6d22d8447f88df0e7245a5b856fb751e507b979bR28)

Let me know if you’d like to discuss how these changes affect your workflow or if you have questions about the new resource or plugin setup!