### PR TITLE
Fix KMP plugin

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
     compileOnly(libs.room.gradlePlugin)
     compileOnly(libs.dependencyGuard.gradlePlugin)
     compileOnly(libs.compose.compiler.gradlePlugin)
-    compileOnly(libs.androidx.benchmark.gradlePlugin)
 }
 
 tasks {

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -20,13 +20,14 @@ kotlin {
 dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.androidx.benchmark.gradlePlugin)
+    compileOnly(libs.compose.compiler.gradlePlugin)
+    compileOnly(libs.compose.gradlePlugin)
+    compileOnly(libs.dependencyGuard.gradlePlugin)
     compileOnly(libs.firebase.crashlytics.gradlePlugin)
     compileOnly(libs.firebase.performance.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.ksp.gradlePlugin)
     compileOnly(libs.room.gradlePlugin)
-    compileOnly(libs.dependencyGuard.gradlePlugin)
-    compileOnly(libs.compose.compiler.gradlePlugin)
 }
 
 tasks {

--- a/build-logic/convention/src/main/kotlin/KeelimMultiPlatformConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KeelimMultiPlatformConventionPlugin.kt
@@ -3,6 +3,9 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.compose.ComposeExtension
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
@@ -14,8 +17,11 @@ class KeelimMultiPlatformConventionPlugin : Plugin<Project> {
             apply(plugin = libs.findPlugin("kotlinMultiplatform").get().get().pluginId)
             apply(plugin = libs.findPlugin("compose-multiplatform").get().get().pluginId)
             apply(plugin = libs.findPlugin("compose-compiler").get().get().pluginId)
+
+            val composeDependencies = extensions.getByType<ComposeExtension>().dependencies
             extensions.configure<KotlinMultiplatformExtension> {
                 jvm("desktop")
+                androidTarget()
                 if (project.name.contains("shared").not()) {
                     wasmJs {
                         outputModuleName.set("composeApp")
@@ -38,7 +44,23 @@ class KeelimMultiPlatformConventionPlugin : Plugin<Project> {
                         binaries.executable()
                     }
                 }
-                androidTarget()
+                sourceSets.apply {
+                    commonMain {
+                        dependencies {
+                            implementation(composeDependencies.runtime)
+                            implementation(composeDependencies.foundation)
+                            implementation(composeDependencies.material3)
+                            implementation(composeDependencies.materialIconsExtended)
+                            implementation(composeDependencies.ui)
+                            implementation(composeDependencies.components.resources)
+                            implementation(composeDependencies.components.uiToolingPreview)
+                        }
+                    }
+                }
+            }
+            dependencies {
+                "debugImplementation"(composeDependencies.uiTooling)
+                "debugImplementation"(composeDependencies.preview)
             }
         }
     }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -13,13 +13,6 @@ kotlin {
     sourceSets {
         val desktopMain by getting
         commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.materialIconsExtended)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
             implementation(projects.core.component)
         }
         desktopMain.dependencies {

--- a/core/component/build.gradle.kts
+++ b/core/component/build.gradle.kts
@@ -26,13 +26,6 @@ kotlin {
             implementation(project.dependencies.platform(libs.androidx.compose.bom))
         }
         commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.materialIconsExtended)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
             implementation(project.dependencies.platform(libs.coil.bom))
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -213,6 +213,7 @@ coil-network-ktor = { group = "io.coil-kt", name = "coil-video", version.ref = "
 coil-svg = { group = "io.coil-kt", name = "coil-svg"}
 coil-video = { group = "io.coil-kt", name = "coil-video"}
 compose-compiler-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
+compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
 zxing = { module = "com.google.zxing:core", version.ref = "zxing" }
 deeplinkdispatch = { group = "com.airbnb", name = "deeplinkdispatch", version.ref = "deeplinkdispatch" }
 deeplinkdispatch-processor = { group = "com.airbnb", name = "deeplinkdispatch-processor", version.ref = "deeplinkdispatch" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -25,7 +25,6 @@ kotlin {
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.okio)
             implementation(libs.circuit.foundation)
-            implementation(compose.components.resources)
 
             api(projects.core.resource)
             api(libs.androidx.dataStore.preferences)


### PR DESCRIPTION
This pull request refactors how Compose dependencies are managed for multiplatform modules. The main improvement is centralizing Compose dependency declarations in the convention plugin, which reduces duplication and simplifies dependency management across modules. Additionally, some plugin and dependency declarations are cleaned up and reordered for clarity.

**Compose dependency management improvements:**

* Compose dependencies (`runtime`, `foundation`, `material3`, `materialIconsExtended`, `ui`, `components.resources`, `components.uiToolingPreview`) are now added to `commonMain` source set via the `KeelimMultiPlatformConventionPlugin`, removing the need for manual declarations in module build files. [[1]](diffhunk://#diff-3261c681a5d672208c62b037e1c257dbf17c23faf6496bcea1ca74fb5f1b213bL41-R63) [[2]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aL16-L22) [[3]](diffhunk://#diff-98f9d0f4387222373357a1797238f12fe200ba94fd8b1d06f10d0cba9a7a7ae8L29-L35) [[4]](diffhunk://#diff-cf9ae3b1eb7273a914f22b1e6d22d8447f88df0e7245a5b856fb751e507b979bL28)
* Debug-only Compose dependencies (`uiTooling`, `preview`) are added via the convention plugin, ensuring consistent tooling support in debug builds.

**Plugin and dependency declaration updates:**

* Added `compose-gradlePlugin` to `libs.versions.toml` for easier plugin management.
* Reordered and cleaned up `compileOnly` plugin dependencies in `build-logic/convention/build.gradle.kts` for clarity and to avoid duplication.

**Convention plugin enhancements:**

* The convention plugin now imports additional DSL utilities and retrieves Compose dependencies using `ComposeExtension`, enabling the centralized dependency management. [[1]](diffhunk://#diff-3261c681a5d672208c62b037e1c257dbf17c23faf6496bcea1ca74fb5f1b213bR6-R8) [[2]](diffhunk://#diff-3261c681a5d672208c62b037e1c257dbf17c23faf6496bcea1ca74fb5f1b213bR20-R24)